### PR TITLE
Update search bar placeholder text

### DIFF
--- a/frontend/components/shopping/ShoppingListView.tsx
+++ b/frontend/components/shopping/ShoppingListView.tsx
@@ -587,7 +587,7 @@ const ShoppingListView: React.FC<ShoppingListViewProps> = ({
             <Stack direction="row" spacing={2} alignItems="center">
               <TextField
                 size="small"
-                placeholder="Search items..."
+                placeholder="Search"
                 value={searchQuery}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
                 sx={{ 


### PR DESCRIPTION
Change search bar placeholder text to "Search" instead of "Search items".