### PR TITLE
Fix category reorganization persistence bug

### DIFF
--- a/CATEGORY_REORGANIZATION_BUGFIX.md
+++ b/CATEGORY_REORGANIZATION_BUGFIX.md
@@ -1,0 +1,66 @@
+# Category Reorganization Bug Fix
+
+## Problem
+Category reorganizations were not persisting properly across different shopping lists. When users would drag and drop categories to reorder them in one list, the reorganization would apply to all lists because of a shared localStorage key.
+
+## Root Cause
+The issue was in the `ShoppingListView.tsx` component where the localStorage key for storing category order was using a global key `'categoryOrder'` instead of a list-specific key. This caused all lists to share the same category order.
+
+## Files Modified
+
+### 1. `frontend/components/shopping/ShoppingListView.tsx`
+- **Added `listId` prop**: Updated the `ShoppingListViewProps` interface to include a `listId: string` parameter
+- **Updated component signature**: Modified the component to accept and use the `listId` prop
+- **Fixed localStorage keys**: Changed all localStorage operations from using `'categoryOrder'` to `'categoryOrder_${listId}'`
+- **Updated effect dependencies**: Added `listId` to the dependency arrays of useEffect and useCallback hooks
+
+### 2. `frontend/components/app/ShoppingApp.tsx`
+- **Added listId prop**: Updated the `ShoppingListView` component usage to pass the `selectedListId` as the `listId` prop
+- **Added null check**: Added a conditional render to only show `ShoppingListView` when `selectedListId` is not null
+- **Added fallback UI**: Added a fallback message when no list is selected
+
+## Changes Made
+
+### ShoppingListView.tsx Changes:
+1. Added `listId: string` to the props interface
+2. Updated localStorage key from `'categoryOrder'` to `'categoryOrder_${listId}'` in:
+   - Initial load effect
+   - Category reset effect
+   - Reset category order function
+   - Drag end handler
+3. Updated dependency arrays to include `listId`
+
+### ShoppingApp.tsx Changes:
+1. Added `listId={selectedListId}` prop to ShoppingListView
+2. Added conditional rendering to handle null selectedListId
+3. Added fallback UI for when no list is selected
+
+## Technical Details
+
+### Before (Buggy):
+```typescript
+// All lists shared the same key
+const savedOrder = localStorage.getItem('categoryOrder');
+localStorage.setItem('categoryOrder', JSON.stringify(newOrder));
+```
+
+### After (Fixed):
+```typescript
+// Each list has its own key
+const savedOrder = localStorage.getItem(`categoryOrder_${listId}`);
+localStorage.setItem(`categoryOrder_${listId}`, JSON.stringify(newOrder));
+```
+
+## Testing
+- Build compilation successful ✅
+- TypeScript type checking passed ✅
+- All localStorage operations now use list-specific keys ✅
+
+## Result
+Category reorganizations now persist correctly for each individual shopping list. Users can:
+1. Drag and drop categories in List A to reorder them
+2. Switch to List B and organize categories differently
+3. Return to List A and find their original category order preserved
+4. Each list maintains its own independent category organization
+
+The fix ensures that category reorganizations are properly scoped to individual shopping lists rather than being shared globally across all lists.

--- a/frontend/components/app/ShoppingApp.tsx
+++ b/frontend/components/app/ShoppingApp.tsx
@@ -441,14 +441,21 @@ const ShoppingApp: React.FC<ShoppingAppProps> = ({ user, mode, onToggleMode, onL
                     onExitShoppingMode={handleExitShoppingMode}
                     currentListName={currentListName}
                   />
-                ) : (
+                ) : selectedListId ? (
                   <ShoppingListView
                     items={items}
+                    listId={selectedListId}
                     onToggleComplete={handleToggleComplete}
                     onDeleteItem={handleDeleteItem}
                     onEditItem={handleEditItem}
                     onAddItem={() => setIsAddModalOpen(true)}
                   />
+                ) : (
+                  <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+                    <Typography variant="h6" color="text.secondary">
+                      Select a shopping list to view items
+                    </Typography>
+                  </Box>
                 )}
               </>
             )}

--- a/frontend/components/shopping/ShoppingListView.tsx
+++ b/frontend/components/shopping/ShoppingListView.tsx
@@ -10,6 +10,7 @@ import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea
 
 interface ShoppingListViewProps {
   items: ShoppingItem[];
+  listId: string;
   onToggleComplete: (id: string) => void;
   onDeleteItem: (id: string) => void;
   onEditItem: (item: ShoppingItem) => void;
@@ -60,6 +61,7 @@ const FloatingParticles: React.FC = () => {
 
 const ShoppingListView: React.FC<ShoppingListViewProps> = ({
   items,
+  listId,
   onToggleComplete,
   onDeleteItem,
   onEditItem,
@@ -158,7 +160,7 @@ const ShoppingListView: React.FC<ShoppingListViewProps> = ({
 
   // Load category order from localStorage
   useEffect(() => {
-    const savedOrder = localStorage.getItem('categoryOrder');
+    const savedOrder = localStorage.getItem(`categoryOrder_${listId}`);
     if (savedOrder) {
       try {
         const parsedOrder = JSON.parse(savedOrder);
@@ -168,10 +170,10 @@ const ShoppingListView: React.FC<ShoppingListViewProps> = ({
       } catch (error) {
         console.warn('Failed to parse stored category order:', error);
         // Clear invalid data
-        localStorage.removeItem('categoryOrder');
+        localStorage.removeItem(`categoryOrder_${listId}`);
       }
     }
-  }, []);
+  }, [listId]);
 
   // Reset custom order if categories have changed significantly
   useEffect(() => {
@@ -183,10 +185,10 @@ const ShoppingListView: React.FC<ShoppingListViewProps> = ({
       if (!hasValidCustomOrder) {
         // Reset to empty array to fall back to alphabetical sorting
         setCategoryOrder([]);
-        localStorage.removeItem('categoryOrder');
+        localStorage.removeItem(`categoryOrder_${listId}`);
       }
     }
-  }, [groupedItems, categoryOrder]);
+  }, [groupedItems, categoryOrder, listId]);
 
   const toggleCategoryCollapse = useCallback((category: string) => {
     setCollapsedCategories(prev => {
@@ -214,8 +216,8 @@ const ShoppingListView: React.FC<ShoppingListViewProps> = ({
 
   const resetCategoryOrder = useCallback(() => {
     setCategoryOrder([]);
-    localStorage.removeItem('categoryOrder');
-  }, []);
+    localStorage.removeItem(`categoryOrder_${listId}`);
+  }, [listId]);
 
   const handleDragStart = useCallback(() => {
     setIsDragging(true);
@@ -240,8 +242,8 @@ const ShoppingListView: React.FC<ShoppingListViewProps> = ({
 
     // Update state and persist to localStorage
     setCategoryOrder(newOrder);
-    localStorage.setItem('categoryOrder', JSON.stringify(newOrder));
-  }, [sortedCategories]);
+    localStorage.setItem(`categoryOrder_${listId}`, JSON.stringify(newOrder));
+  }, [sortedCategories, listId]);
 
   const getPriorityIcon = useCallback((priority: string) => {
     switch (priority) {


### PR DESCRIPTION
Make category reorganizations persist per shopping list by using list-specific localStorage keys.

Previously, category reorganizations were stored using a global localStorage key, causing changes made in one shopping list to incorrectly apply to all other lists. This PR updates the storage mechanism to use a unique key for each list, ensuring reorganizations are isolated and persist correctly per list.