### PR TITLE
Adjust login toaster display duration

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
       <Toaster 
         position="top-right"
         toastOptions={{
-          duration: 4000,
+          duration: 6000,
           style: {
             borderRadius: '8px',
             background: theme.palette.background.paper,

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -43,12 +43,14 @@ export const useAuth = () => {
       localStorage.setItem('authToken', data.token);
       localStorage.setItem('currentUser', JSON.stringify(userData));
       
-      toast.success(`Welcome back, ${userData.username || userData.email}! 🎉`);
+      toast.success(`Welcome back, ${userData.username || userData.email}! 🎉`, {
+        duration: 8000, // Show login toast for 8 seconds
+      });
       
-      // Force immediate redirect by reloading the page
+      // Allow time for the toast to be seen before reloading
       setTimeout(() => {
         window.location.reload();
-      }, 100);
+      }, 2000);
       
       return { success: true };
     } catch (error: any) {


### PR DESCRIPTION
Improve login toast visibility by extending its display duration and delaying page reload.

Previously, the login success toast was barely visible because the page reloaded after only 100ms, cutting off the toast display which had a global duration of 4 seconds.